### PR TITLE
Fixing the backward slash issue in img src on TestPage2.html

### DIFF
--- a/TestPage2.html
+++ b/TestPage2.html
@@ -19,7 +19,7 @@
         <header class="inner">
           <a id="forkme_banner" href="https://github.com/OpenLiveWriter">View on GitHub</a>
 
-          <h1 id="project_title"><img src="http://openlivewriter.github.io\images\openlivewriter-purpleheader.png"></img></h1>
+          <h1 id="project_title"><img src="http://openlivewriter.github.io/images/openlivewriter-purpleheader.png"></img></h1>
           <!--
           <button onclick="javascript:location.href='https://openlivewriter.azureedge.net/stable/Releases/Setup.exe'">Download</button>
           -->


### PR DESCRIPTION
The testpage2.html had src tag with backward slash for header image.
