### PR TITLE
Add news page and gitignore file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+# ignore jekyll output
+_site

--- a/_includes/news_item.html
+++ b/_includes/news_item.html
@@ -1,0 +1,19 @@
+<article>
+  <h2>
+    <a href="{{ post.url }}">
+      {{ post.title }}
+    </a>
+  </h2>
+  <div class="post-meta">
+    <span class="post-date">
+      {{ post.date | date_to_string }}
+    </span>
+    <a href="https://github.com/{{ post.author }}" class="post-author">
+      <img src="https://github.com/{{ post.author }}.png" class="avatar" alt="{{ post.author }} avatar" width="24" height="24">
+      {{ post.author }}
+    </a>
+  </div>
+  <div class="post-content">
+    {{ post.content }}
+  </div>
+</article>

--- a/_posts/2015-12-09-initial-public-release.md
+++ b/_posts/2015-12-09-initial-public-release.md
@@ -1,0 +1,30 @@
+---
+layout: default
+title: 'Initial public release'
+version: 0.5.0.0
+categories: [release]
+date: 2015-12-09 00:00:00 -0800
+author: martinwoodward
+download: true
+---
+First open source release of Open Live Writer!
+
+### Installation
+
+Install from http://www.OpenLiveWriter.org
+
+You can install the latest version of Open Live Writer alongside an older version of Windows Live Writer.
+
+### Details
+
+For a list of known issues see GitHub or take a
+look at the roadmap to see what the current plans are.
+
+For the latest news and updates about Open Live Writer, you can follow us on Twitter 
+(@OpenLiveWriter), by keeping an eye on the website
+http://www.OpenLiveWriter.org or by watching this repo and subscribing to notifications.
+
+### Downloads
+[Source Code (zip)](https://github.com/OpenLiveWriter/OpenLiveWriter/archive/0.5.0.0.zip)
+
+[Source Code (tar.gz)](https://github.com/OpenLiveWriter/OpenLiveWriter/archive/0.5.0.0.tar.gz)

--- a/_posts/2015-12-17-blogger-v3-api-support.md
+++ b/_posts/2015-12-17-blogger-v3-api-support.md
@@ -1,0 +1,17 @@
+---
+layout: default
+title: 'Blogger V3 API Support'
+version: 0.5.1.2
+categories: [release]
+date: 2015-12-17 00:00:00 -0800
+author: martinwoodward
+download: true
+---
+This release provides the initial version of Blogger support using their latest API to unblock users of Blogger.
+
+To force an update, visit [http://openlivewriter.org](http://openlivewriter.org) then download and run the installer. Otherwise if you start Open Live Writer and wait a minute or so, next time you restart Live Writer you should be running the latest version (go to Help, About Open Live Writer to see what version you are on)
+
+### Downloads
+[Source Code (zip)](https://github.com/OpenLiveWriter/OpenLiveWriter/archive/0.5.1.2.zip)
+
+[Source Code (tar.gz)](https://github.com/OpenLiveWriter/OpenLiveWriter/archive/0.5.1.2.tar.gz)

--- a/news/index.html
+++ b/news/index.html
@@ -1,0 +1,10 @@
+---
+layout: default
+title: News
+permalink: /news/
+download: true
+---
+
+{% for post in site.posts %}
+  {% include news_item.html %}
+{% endfor %}

--- a/stylesheets/stylesheet.css
+++ b/stylesheets/stylesheet.css
@@ -357,8 +357,24 @@ Full-Width Styles
   background: #212121;
 }
 
+article {
+  padding: 40px 0 30px;
+}
 
+article h2 {
+  padding-bottom: 0px;
+}
 
+.post-meta {
+  padding: 5px 0;
+  font-weight: 600;
+}
+
+.avatar {
+  border-radius: 3px;
+  display: inline-block;
+  vertical-align: middle;
+}
 /*******************************************************************************
 Small Device Styles
 *******************************************************************************/


### PR DESCRIPTION
Write news, release notes or any other announcements in `openlivewriter.github.io/_posts` then they can be included in `openlivewriter.org/news/` page.

Currently I'm not sure where to put the link of `/news/` in the homepage. Besides, it would be great if we have a rss feed for users to subscribe, then users can get our update ASAP.

The output would be like

![](https://files.gitter.im/OpenLiveWriter/OpenLiveWriter/K3jL/blob)