### PR TITLE
Removed X-UA-Compatible Meta Tag

### DIFF
--- a/_includes/head.html
+++ b/_includes/head.html
@@ -9,7 +9,6 @@
   <title>{{ page.title }}</title>
   {% if page.keywords %}<meta name="keywords" content="{{ page.keywords }}">{% endif %}
   <link href="/favicon.ico" rel="shortcut icon">
-  <meta http-equiv="X-UA-Compatible" content="chrome=1">
   <link rel="stylesheet" type="text/css" media="screen" href="/stylesheets/stylesheet.css">
   <link rel="stylesheet" type="text/css" media="screen" href="/stylesheets/downloadbutton.css">
 </head>	


### PR DESCRIPTION
The ```<meta http-equiv="X-UA-Compatible" content="chrome=1" />``` has been included in this file, Chrome Frame has been discontinued. This flags an issue with the site scanner https://dev.windows.com/en-us/microsoft-edge/tools/staticscan. Since it is most likely is providing no value It would be best to remove.