### PR TITLE
Fixed the link pointing to wrong repository

### DIFF
--- a/404.html
+++ b/404.html
@@ -7,6 +7,6 @@ subtitle: "Whoops! Page Not Found"
 <p>Sorry - we're in the process of getting the new Open Live Writer website set up and you appear to have tried to
   visit a page that doesn't exist yet.</p>
 <p>If you don't mind, please 
-<a target="_blank" href="https://github.com/OpenLiveWriter/OpenLiveWriter/issues/new">log an issue</a> 
+<a target="_blank" href="https://github.com/OpenLiveWriter/OpenLiveWriter.Github.io/issues/new">log an issue</a> 
 with the URL you were trying to reach and where you clicked in Open Live Writer to get sent here. Thanks!
 </p>


### PR DESCRIPTION
The link to create a new issue in `404.html` pointed to the main OpenLiveWriter repo. I have updated it to point to the website's repo.