### PR TITLE
Fixes #39 (Both openlivewriter.org/blogs and openlivewriter.org/news are now up)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 # ignore jekyll output
 _site
+.vscode

--- a/README.md
+++ b/README.md
@@ -30,6 +30,29 @@ For more information see the [.NET Foundation Code of Conduct](http://www.dotnet
 For developer chatter, head on over to the [OpenLiveWriter Gitter room]((https://gitter.im/OpenLiveWriter/OpenLiveWriter?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge)):
 [![Gitter](https://badges.gitter.im/Join%20Chat.svg)](https://gitter.im/OpenLiveWriter/OpenLiveWriter?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge)
 
+### For the people writing posts and news items:
+
+All the files within **`_posts`** should have this section at the top of the file.
+
+```
+---
+layout: default
+title: 'Initial public release'
+version: 0.5.0.0
+categories: [release, news]
+date: 2015-12-09 00:00:00 -0800
+author: martinwoodward
+download: true
+---
+```
+Do not change the `layout`.  
+`title`: The text that you want to see on the page.  
+`version`: The version number of OLW about which the post is concerned.  
+`categories`: Comma separated categories within braces. If this contains `blog` it goes to `/blog`, if it contains `news` it goes to `/news`. If both, then it will be present in both places.  
+`date`: yyyy-mm-dd hh:mm:ss timezone (timezone is of the form +0530 or -0800, ie. +/-hhmm).  
+`author` is the GitHub username of the author. Used to link to their profile and show a small gravatar.  
+`download`: I'm not sure what this does but let it be.
+
 ### .NET Foundation
 The Open Live Writer project is supported by the [.NET Foundation](http://www.dotnetfoundation.org).
 

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -31,7 +31,7 @@
           <ul class="nav navbar-nav">
             <li><a href="http://openlivewriter.org">Home</a></li>
             <li><a href="http://openlivewriter.org/news/">News</a></li>
-            <li><a href="http://openlivewriter.org/WriterRedirect/WriterBlog">Blog</a></li>
+            <li><a href="http://openlivewriter.org/blog/">Blog</a></li>
           </ul>
         </div><!-- /.navbar-collapse -->
       </div><!-- /.container-fluid -->

--- a/_posts/2015-12-09-initial-public-release.md
+++ b/_posts/2015-12-09-initial-public-release.md
@@ -2,7 +2,7 @@
 layout: default
 title: 'Initial public release'
 version: 0.5.0.0
-categories: [release]
+categories: [release, news]
 date: 2015-12-09 00:00:00 -0800
 author: martinwoodward
 download: true

--- a/_posts/2015-12-17-blogger-v3-api-support.md
+++ b/_posts/2015-12-17-blogger-v3-api-support.md
@@ -2,7 +2,7 @@
 layout: default
 title: 'Blogger V3 API Support'
 version: 0.5.1.2
-categories: [release]
+categories: [release, news]
 date: 2015-12-17 00:00:00 -0800
 author: martinwoodward
 download: true

--- a/_posts/2016-01-16-Contributing-to-Open-Live-Writer.md
+++ b/_posts/2016-01-16-Contributing-to-Open-Live-Writer.md
@@ -1,3 +1,12 @@
+---
+layout: default
+title: 'Contributing to Open Live Writer'
+categories: [blog]
+date: 2016-01-16 00:00:00 -0800
+author: kathweaver
+download: true
+---
+
 ###Contributing to Open Live Writer
 I have been using the original Live Writer since it came out, and loved it.  I was 
 an avid user of the plug-ins too.

--- a/blog/index.html
+++ b/blog/index.html
@@ -1,0 +1,12 @@
+---
+layout: default
+title: Blog
+permalink: /blog/
+download: true
+---
+
+{% for post in site.posts %}
+  {% if post.categories contains 'blog' %}
+    {% include news_item.html %}
+  {% endif %}
+{% endfor %}

--- a/news/index.html
+++ b/news/index.html
@@ -6,5 +6,7 @@ download: true
 ---
 
 {% for post in site.posts %}
-  {% include news_item.html %}
+  {% if post.categories contains 'news' %}
+    {% include news_item.html %}
+  {% endif %}
 {% endfor %}


### PR DESCRIPTION
This change requires a notice for anybody who writes posts.

If the post is intended for the **news** page, the `categories` part should include `news`. If it is intended for the **blog** page, the `categories` part should include `blog`. I'll submit an updated README too so that people can remember.

This was the only option I could come up with. I'll also try writing some rake tasks to automate a lot of the stuff so that people only have to do:
```
rake new blog-post
rake new news-item
```